### PR TITLE
Pubsub auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ target/
 
 mods/
 .vertx
+*.jar
+*.log
+src/main/resources/vertx-default-jul-logging.properties.unused
+mqtt-spy/

--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,12 @@
         </dependency>
 
         <!--Test dependencies-->
+		<dependency>
+		  <groupId>io.vertx</groupId>
+		  <artifactId>vertx-unit</artifactId>
+		  <version>${vertx.version}</version>
+		  <scope>test</scope>
+		</dependency>        
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/src/main/java/io/github/giovibal/mqtt/parser/SubAckEncoder.java
+++ b/src/main/java/io/github/giovibal/mqtt/parser/SubAckEncoder.java
@@ -25,7 +25,11 @@ class SubAckEncoder extends DemuxEncoder<SubAckMessage> {
             buff.writeBytes(Utils.encodeRemainingLength(variableHeaderSize));
             buff.writeShort(message.getMessageID());
             for (AbstractMessage.QOSType c : message.types()) {
-                buff.writeByte(c.ordinal());
+            	if (c == AbstractMessage.QOSType.FAILURE) {
+            		buff.writeByte(AbstractMessage.QOSType.FAILURE_VALUE);
+            	} else {
+            		buff.writeByte(c.ordinal());
+            	}
             }
 
             out.writeBytes(buff);

--- a/src/main/java/org/dna/mqtt/moquette/proto/messages/AbstractMessage.java
+++ b/src/main/java/org/dna/mqtt/moquette/proto/messages/AbstractMessage.java
@@ -40,8 +40,10 @@ public abstract class AbstractMessage {
     public static final byte DISCONNECT = 14; //Client is Disconnecting
 
     public static enum QOSType {
-        MOST_ONE, LEAST_ONE, EXACTLY_ONCE, RESERVED;
+        MOST_ONE, LEAST_ONE, EXACTLY_ONCE, RESERVED, FAILURE;
         
+    	public static final int FAILURE_VALUE = 128;
+    	
         public static String formatQoS(QOSType qos) {
             return String.format("%d - %s", qos.ordinal(), qos.name());
         }

--- a/src/test/java/io/github/giovibal/mqtt/integration/AuthorizationTests.java
+++ b/src/test/java/io/github/giovibal/mqtt/integration/AuthorizationTests.java
@@ -1,0 +1,209 @@
+package io.github.giovibal.mqtt.integration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.log4j.BasicConfigurator;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.eclipse.paho.client.mqttv3.MqttConnectOptions;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.github.giovibal.mqtt.*;
+import io.github.giovibal.mqtt.test.Tester;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.net.NetServer;
+import io.vertx.core.net.NetServerOptions;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+@RunWith(VertxUnitRunner.class)
+public class AuthorizationTests {
+	private static final String AUTHENTICATOR_ADR = "mqtt_authenticator";
+	private Vertx vertx;
+	private NetServer netServer;
+	private JsonObject config;
+	private UserAuthVerticleStub auth;
+	
+	@Before
+	public void setUp(TestContext context) {
+		BasicConfigurator.configure();
+		Logger.getRootLogger().setLevel(Level.INFO);
+		
+		vertx = Vertx.vertx();
+		config = new JsonObject();
+		config.put("tcp_port", 1883);
+		config.put("socket_idle_timeout", 60);
+		config.put("retain_support", false);
+		config.put("authenticator_address", AUTHENTICATOR_ADR);
+		netServer = startTcpBroker(config);
+		
+		auth = new UserAuthVerticleStub(AUTHENTICATOR_ADR);
+		vertx.deployVerticle(auth, context.asyncAssertSuccess());
+	}
+
+	@After
+	public void tearDown(TestContext context) {
+		netServer.close();
+		vertx.close(context.asyncAssertSuccess());
+	}
+
+    @Test
+    public void testBackwardCompatibility(TestContext context) {
+    	try {
+	        String serverURL = "tcp://localhost:"+config.getInteger("tcp_port");
+	        Tester c = new Tester(1, "Paho", serverURL);
+
+	        System.out.println("Check if can connect without password checks");
+	        auth.setLoginRequired(false);
+	        auth.setDoPublishChecks(false);
+	        auth.setDoSubscribeChecks(false);
+	        try {
+	        	c.connect();
+	        } finally {
+	        	c.disconnect();
+	        }
+	        
+	        System.out.println("Check if connect fails without valid password");
+	        auth.setLoginRequired(true);
+	        try {
+	        	c.connect();
+		        context.fail("Credentials not checked");
+	        } catch(Throwable e) {
+	        	// Expected exception
+	        } finally {	   
+				try {c.disconnect();} catch (Exception ex){}	        	
+	        }
+
+	        System.out.println("Check if connect succeeds with valid password");
+	        MqttConnectOptions o = new MqttConnectOptions();
+	        o.setUserName("user1");
+	        o.setPassword("secret".toCharArray());
+	        auth.setUserPass("user1", "secret");
+	        c.connect(o);
+	        
+	        try {
+	        	c.publish("my/special/topic");			// Any publish succeeds
+	        	c.subscribe("my/other/topic");			// Any subscribe succeeds
+	        } finally{
+	        	c.disconnect();
+	        }
+	        
+    	} catch(Throwable e) {
+    		System.out.println("Exception:"+e.getMessage());
+    		context.fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testSubscribeAuthentication(TestContext context) throws MqttException {
+    	Tester c = null;
+    	try {
+	        String serverURL = "tcp://localhost:"+config.getInteger("tcp_port");
+	        c = new Tester(1, "Paho", serverURL);
+
+	        auth.setLoginRequired(true);
+	        auth.setDoSubscribeChecks(true);
+	        auth.setDoPublishChecks(false);
+
+	        MqttConnectOptions o = new MqttConnectOptions();
+	        o.setUserName("user1");
+	        o.setPassword("secret".toCharArray());
+	        auth.setUserPass("user1", "secret");
+	        c.connect(o);
+	        
+	        System.out.println("Check that subscribe to allowed topic works");
+	        String topic = "valid/topic";
+	        auth.setAllowedSubTopic(topic);
+	        c.subscribe(topic);
+	        int count = (int) c.getMessaggiArrivatiPerClient().values().toArray()[0];
+	        c.publish(topic);
+	        count = (int) c.getMessaggiArrivatiPerClient().values().toArray()[0] - count;
+	        c.unsubcribe(topic);	        
+	        context.assertNotEquals(count, 0, "Publish to valid topic not received");
+	        
+	        System.out.println("Check that subscribe to illegal topic throws exception and does not accept messages");
+	        String illegalTopic = "illegal/topic";
+	        try {
+	        	c.subscribe(illegalTopic);
+	        	context.fail("Illegal subscribe topic accepted");
+	        } catch (Throwable e) {
+	        	// Expected exception
+	        }
+	        count = (int) c.getMessaggiArrivatiPerClient().values().toArray()[0];
+	        c.publish(illegalTopic);
+	        count = (int) c.getMessaggiArrivatiPerClient().values().toArray()[0] - count;
+	        c.unsubcribe(illegalTopic);	        
+	        context.assertEquals(count, 0, "Publish to illegal topic succeeded");
+	        
+    	} catch (Throwable e) {
+    		context.fail(e.getMessage());
+    	} finally {
+			try {c.disconnect();} catch (Exception ex){}	        	
+    	}
+    }
+    
+    @Test
+    public void testPublishAuthentication(TestContext context) throws MqttException {
+    	Tester c = null;
+    	try {
+	        String serverURL = "tcp://localhost:"+config.getInteger("tcp_port");
+	        c = new Tester(1, "Paho", serverURL);
+
+	        auth.setLoginRequired(true);
+	        auth.setDoSubscribeChecks(false);
+	        auth.setDoPublishChecks(true);
+
+	        MqttConnectOptions o = new MqttConnectOptions();
+	        o.setUserName("user1");
+	        o.setPassword("secret".toCharArray());
+	        auth.setUserPass("user1", "secret");
+	        c.connect(o);
+	        
+	        System.out.println("Check that publish to allowed topic works");
+	        String topic = "valid/topic";
+	        auth.setAllowedPubTopic(topic);
+	        c.subscribe(topic);
+	        int count = (int) c.getMessaggiArrivatiPerClient().values().toArray()[0];
+	        c.publish(topic);
+	        count = (int) c.getMessaggiArrivatiPerClient().values().toArray()[0] - count;
+	        c.unsubcribe(topic);	        
+	        context.assertNotEquals(count, 0, "Publish to valid topic not received");
+	        
+	        System.out.println("Check that publish to illegal topic does not send messages");
+	        String illegalTopic = "illegal/topic";
+	        c.subscribe(illegalTopic);
+	        count = (int) c.getMessaggiArrivatiPerClient().values().toArray()[0];
+        	c.publish(illegalTopic);			// Illegal publish fails silently
+	        count = (int) c.getMessaggiArrivatiPerClient().values().toArray()[0] - count;
+	        c.unsubcribe(illegalTopic);	        
+	        context.assertEquals(count, 0, "Publish to illegal topic sent message");
+	        
+    	} catch (Throwable e) {
+    		context.fail(e.getMessage());
+    	} finally {
+			try {c.disconnect();} catch (Exception ex){}	        	
+    	}
+    }
+    
+    private NetServer startTcpBroker(JsonObject conf) {
+
+		ConfigParser c = new ConfigParser(conf);
+
+		NetServerOptions opt = new NetServerOptions().setTcpKeepAlive(true)
+				.setIdleTimeout(conf.getInteger("socket_idle_timeout")).setPort(conf.getInteger("tcp_port"));
+
+		NetServer netServer = vertx.createNetServer(opt);
+		netServer.connectHandler(netSocket -> {
+			Map<String, MQTTSession> sessions = new HashMap<>();
+			MQTTNetSocket mqttNetSocket = new MQTTNetSocket(vertx, c, netSocket, sessions);
+			mqttNetSocket.start();
+		}).listen();
+		return netServer;
+	}
+}

--- a/src/test/java/io/github/giovibal/mqtt/integration/UserAuthVerticleStub.java
+++ b/src/test/java/io/github/giovibal/mqtt/integration/UserAuthVerticleStub.java
@@ -1,0 +1,128 @@
+package io.github.giovibal.mqtt.integration;
+
+import io.vertx.core.AbstractVerticle;
+import io.vertx.core.eventbus.EventBus;
+import io.vertx.core.eventbus.MessageConsumer;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+
+public class UserAuthVerticleStub extends AbstractVerticle {
+	private static final String TOKEN = "ABCDEF";
+	private String evtBusAddress;
+	private boolean loginRequired = true;
+	private boolean doSubscribeChecks = false;
+	private boolean doPublishChecks = false;
+	private String allowedPubTopic = null;
+	private boolean pubTopicMustMatch = true;
+	private String allowedSubTopic = null;
+	private boolean subTopicMustMatch = true;
+	private String user = "";
+	private String password = "";
+	@SuppressWarnings("rawtypes")
+	private MessageConsumer connectConsumer, pubConsumer, subConsumer;
+	
+	public UserAuthVerticleStub(String evtBusAddress) {
+		super();
+		this.evtBusAddress = evtBusAddress;
+	}
+
+	public void setLoginRequired(boolean login) {
+		this.loginRequired = login;
+	}
+	public void setDoPublishChecks(boolean check) {
+		this.doPublishChecks = check;
+	}
+	public void setDoSubscribeChecks(boolean check) {
+		this.doSubscribeChecks = check;
+	}
+	public void setAllowedPubTopic(String topic) {
+		this.allowedPubTopic = topic;
+	}
+	public void setPubTopicMustMatch(boolean match) {
+		this.pubTopicMustMatch = match;
+	}
+	public void setAllowedSubTopic(String topic) {
+		this.allowedSubTopic = topic;
+	}
+	public void setSubTopicMustMatch(boolean match) {
+		this.subTopicMustMatch = match;
+	}
+	public void setUserPass(String user, String password) {
+		this.user = user;
+		this.password = password;
+	}
+	@Override
+	public void start() throws Exception {
+		EventBus eb = vertx.eventBus();
+
+		/**
+		 * Connect
+		 */
+		connectConsumer = eb.consumer(evtBusAddress, message -> {
+			JsonObject credentials = new JsonObject(message.body().toString());
+			JsonObject json = new JsonObject();
+			if (loginRequired) {
+				json.put("auth_valid", user.equals(credentials.getString("username")) 
+										&& password.equals(credentials.getString("password")));
+			} else {
+				json.put("auth_valid", true);
+			}
+            json.put("authorized_user", credentials.getString("username"));
+            json.put("error_msg", "");
+            if (doPublishChecks || doSubscribeChecks) {
+            	json.put("token", TOKEN);
+            }
+			message.reply(json);
+		});
+		
+		/**
+		 * Check if allowed to publish
+		 */
+		pubConsumer = eb.consumer(evtBusAddress+".publish", message -> {
+			boolean match = true;
+			if (doPublishChecks) {
+				JsonObject publish = new JsonObject(message.body().toString());
+				String topic = publish.getString("topic");
+				if (topic == null) {
+					match = false;
+				} else {
+					if (!topic.equals(allowedPubTopic)) {
+						match = false;
+					}
+				}
+				if (!pubTopicMustMatch) {
+					match = !match;
+				}
+			}
+			JsonObject reply = new JsonObject();
+			reply.put("permitted", match);
+			message.reply(reply);
+		});
+		
+		/**
+		 * Check if allowed to subscribe
+		 */
+		subConsumer = eb.consumer(evtBusAddress+".subscribe", message -> {
+			JsonObject subscribe = new JsonObject(message.body().toString());
+			JsonArray topics = subscribe.getJsonArray("topics");
+			JsonArray result = new JsonArray();
+			for (int i=0; i < topics.size(); i++) {
+				if (doSubscribeChecks) {
+					result.add(topics.getString(i).equals(allowedSubTopic));
+				} else {
+					result.add(true);
+				}
+			}
+			JsonObject reply = new JsonObject();
+			reply.put("permitted", result);
+			message.reply(reply);
+		});
+	}
+	@Override
+	public void stop() throws Exception {
+		connectConsumer.unregister();
+		pubConsumer.unregister();
+		subConsumer.unregister();
+	}
+}

--- a/src/test/java/io/github/giovibal/mqtt/test/Tester.java
+++ b/src/test/java/io/github/giovibal/mqtt/test/Tester.java
@@ -138,7 +138,11 @@ public class Tester {
             client.connect(o);
         }
     }
-
+    public void connect(MqttConnectOptions o) throws MqttException {
+        for (IMqttClient client : clients) {
+        	client.connect(o);
+        }
+    }
     public void disconnect() throws MqttException {
         log("disconnet ...");
         for(IMqttClient client : clients) {


### PR DESCRIPTION
## Topic based authorization

The user authorization verticle can permit or refuse publishes and subscribes on a per topic basis.

The changes should be backward compatible with the existing implementation.

On a connect the auth verticle optionally adds a 'token' field to the reply json object. Thereafter, the mqtt session checks if a token was returned. If it was, it checks with the auth verticle on each publish and subscribe if that operation and topic is permitted.  These checks are sent via the eventbus address of the auth verticle, but with '.publish' or '.subscribe' appended.

Integration level tests are included.